### PR TITLE
Remove the Unsupported theme options in the conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,20 +83,10 @@ templates_path = ['_templates']
 
 html_show_sourcelink = False
 html_theme_options = {
-    'nav_title': '',
-     # Set the color and the accent color
-    'color_primary': 'blue-grey,',
-    'color_accent': 'white',
-    # Visible levels of the global TOC; -1 means unlimited
-    'globaltoc_depth': 0,
     # If False, expand all TOC entries
     'globaltoc_collapse': False,
     # If True, show hidden TOC entries
     'globaltoc_includehidden': False,
-    'base_url': "https://docs.anuket.io/",
-    'repo_url': 'https://gerrit.opnfv.org/',
-    'repo_name': '',
-    'repo_type': 'github',
 }
 
 # Inverse png


### PR DESCRIPTION
Remove the Unsupported theme options in the conf.py 
The unsupported theme options are :
1.  unsupported theme option 'nav_title'
2. unsupported theme option 'color_primary' 
3. unsupported theme option 'color_accent' 
4. unsupported theme option 'globaltoc_depth'
5. unsupported theme option 'base_url' 
6. unsupported theme option 'repo_url' 
7. unsupported theme option 'repo_name' 
8. unsupported theme option 'repo_type' 
